### PR TITLE
fix(ui): 修复 Cloudflare 代理开关不显示的问题

### DIFF
--- a/src/components/layout/RootLayout.tsx
+++ b/src/components/layout/RootLayout.tsx
@@ -36,7 +36,7 @@ export function RootLayout() {
   const isMobile = useIsMobile()
 
   const { checkForUpdates, showUpdateDialog, setShowUpdateDialog } = useUpdaterStore()
-  const { accounts, checkRestoreStatus } = useAccountStore()
+  const { accounts, checkRestoreStatus, fetchProviders } = useAccountStore()
   const { loadFromStorage, refreshAllAccounts } = useDomainStore()
 
   // 初始化
@@ -44,8 +44,9 @@ export function RootLayout() {
     initTheme()
     initDebugMode()
     checkRestoreStatus()
+    fetchProviders()
     loadFromStorage()
-  }, [checkRestoreStatus, loadFromStorage])
+  }, [checkRestoreStatus, fetchProviders, loadFromStorage])
 
   // 账户加载完成后，清理无效记录并后台刷新域名
   useEffect(() => {


### PR DESCRIPTION
## 总结

- 修复了 DNS 记录页面中 Cloudflare 代理开关（橙云/灰云）不显示的问题

## 问题描述

在 DNS 记录页面，Cloudflare 账户应该显示代理开关（Proxied 列），但实际上该列没有显示。

### 问题原因

`DnsRecordPage` 组件通过 `providerFeatures?.proxy` 判断是否显示代理开关：

```tsx
// src/components/domains/DnsRecordPage.tsx:62-66
const providerFeatures = useMemo(() => {
  if (!selectedAccount) return null
  const provider = providers.find((p) => p.id === selectedAccount.provider)
  return provider?.features ?? null
}, [selectedAccount, providers])

// :86
supportsProxy={providerFeatures?.proxy ?? false}
```

这里的 `providers` 数据来自 `useAccountStore`，需要调用 `fetchProviders()` 从后端获取。

问题在于：应用初始化时只调用了 `checkRestoreStatus()` 和 `loadFromStorage()`，**没有调用 `fetchProviders()`**，导致 `providers` 数组始终为空，`providerFeatures` 永远是 `null`，代理开关自然就不会显示了。

## 解决方案

在 `RootLayout` 组件的初始化 `useEffect` 中添加 `fetchProviders()` 调用，确保应用启动时加载 provider 元数据：

```tsx
// src/components/layout/RootLayout.tsx
useEffect(() => {
  initTheme()
  initDebugMode()
  checkRestoreStatus()
  fetchProviders()  // 新增：加载 provider 数据
  loadFromStorage()
}, [checkRestoreStatus, fetchProviders, loadFromStorage])
```

## Test Plan

- [x] 桌面端：添加 Cloudflare 账户，进入 DNS 记录页面，确认代理开关正常显示
- [x] 桌面端：点击代理开关，确认可以正常切换代理状态
- [x] 其他 provider（阿里云、腾讯云等）不受影响，不显示代理开关列