### PR TITLE
feat(error-handling): 增强阿里云DNS和Cloudflare错误码映射

### DIFF
--- a/docs/release-notes/v1.5.2.md
+++ b/docs/release-notes/v1.5.2.md
@@ -1,0 +1,64 @@
+# v1.5.2 发行说明
+
+## 概述
+
+v1.5.2 是一个错误处理增强版本，大幅扩展了阿里云 DNS 和 Cloudflare 的错误码映射覆盖范围，使错误信息更加准确和友好。
+
+## 改进
+
+### 阿里云 DNS 错误码映射增强
+
+新增约 40 个错误码的精确映射，涵盖以下类别：
+
+**配额/频率限制**：
+- `QuotaExceeded.ARecord`、`QuotaExceeded.Record`、`Throttling` 等限流错误现可正确识别
+
+**域名状态**：
+- `DomainRecordLocked`、`DomainExpiredDNSForbidden` 等域名锁定/过期错误
+- 支持黑洞状态识别（`RecordForbidden.BlackHole`）
+
+**权限控制**：
+- `Forbidden`、`OperationDomain.NoPermission`、`IllegalUser` 等权限错误
+
+**参数验证**：
+- 记录类型（`InvalidRR.TypeEmpty`）
+- 记录值（`InvalidRR.AValue`、`InvalidRR.AAAAValue` 等）
+- 主机记录（`InvalidRR.RrEmpty`、`InvalidRR.Format`）
+- TTL（`SubDomainInvalid.TTL`）
+- 线路（`SubDomainInvalid.Line`、`UnsupportedLine`）
+- MX 优先级（`SubDomainInvalid.Priority`）
+- 域名格式（`InvalidDomainName.Format`、`DomainEmpty`）
+
+### Cloudflare 错误码映射增强
+
+新增约 15 个错误码的精确映射：
+
+**认证错误扩展**：
+- 新增 `6003`（无效请求头）、`6103`（X-Auth-Key 格式错误）、`6111`（Authorization 格式错误）
+
+**参数验证**：
+- `1004`（DNS 验证错误）
+- `9000`（无效名称）、`9005`（IPv4 格式错误）、`9006`（IPv6 格式错误）
+- `9009`（MX 记录值错误）、`9021`（TTL 范围错误）、`9041`（不支持代理）
+
+**记录冲突扩展**：
+- `81053`-`81058` 系列：精确识别 A/AAAA/CNAME/NS 记录冲突
+
+**配额限制**：
+- `81045`（记录配额超限）
+
+**Zone 不存在**：
+- 新增 `7000`（无效 URI 路由）
+
+## 技术统计
+
+- **修改文件**：5 个
+- **新增代码**：+243 行
+- **删除代码**：-30 行
+- **净增加**：+213 行
+
+## 升级说明
+
+从 v1.5.1 升级无需额外操作，直接安装新版本即可。
+
+此版本不涉及 API 变更，仅增强了错误信息的可读性和准确性。

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dns-orchestrator",
   "private": true,
-  "version": "1.5.1",
+  "version": "1.5.2",
   "author": "AptS:1547 (Yuhan Bian / 卞雨涵 <apts-1547@esaps.net>)",
   "type": "module",
   "scripts": {

--- a/src-actix-web/Cargo.lock
+++ b/src-actix-web/Cargo.lock
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "dns-orchestrator-web"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "actix-service",
  "actix-web",

--- a/src-actix-web/Cargo.toml
+++ b/src-actix-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dns-orchestrator-web"
-version = "1.5.1"
+version = "1.5.2"
 description = "DNS Orchestrator built with Actix-web"
 license = "MIT"
 authors = ["AptS-1547 <apts-1547@esaps.net>"]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1390,7 +1390,7 @@ dependencies = [
 
 [[package]]
 name = "dns-orchestrator-tauri"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "async-trait",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dns-orchestrator-tauri"
-version = "1.5.1"
+version = "1.5.2"
 description = "DNS Orchestrator built with Tauri"
 license = "MIT"
 authors = ["AptS-1547 <apts-1547@esaps.net>"]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DNS Orchestrator",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "identifier": "net.esaps.dns-orchestrator",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
This pull request releases version 1.5.2, focusing on significantly enhancing error code mapping for both Aliyun DNS and Cloudflare, resulting in more accurate and user-friendly error messages. No API changes are introduced; the update is backward compatible and requires no special upgrade steps.

**Release and Version Updates**
* Bumped version numbers to `1.5.2` in `package.json`, `src-actix-web/Cargo.toml`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json` to reflect the new release. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4) [[2]](diffhunk://#diff-ffa2288359249b4e48c8d3d790339e35d3eab621764a10576d91b377160a9f51L3-R3) [[3]](diffhunk://#diff-fe4c6a80a21e81339e2e0faeb9134d0f9636c168987df13c8abf1927a1caee39L3-R3) [[4]](diffhunk://#diff-fa09f1dac39604a735cd6a53957d3c35e0c3298cca9cf4829180f167abbd69b7L4-R4)

**Error Code Mapping Enhancements**
* Expanded Aliyun DNS error code mapping by adding around 40 precise mappings, covering quota limits, domain status, permission, parameter validation, and more.
* Expanded Cloudflare error code mapping with about 15 new precise mappings, including authentication, parameter validation, record conflict, quota, and zone errors.

**Documentation**
* Added detailed release notes in `docs/release-notes/v1.5.2.md`, summarizing the improvements, technical statistics, and upgrade instructions.

close #7 