### PR TITLE
chore(scripts): 更新版本同步脚本中的Tauri路径

### DIFF
--- a/scripts/sync-version.mjs
+++ b/scripts/sync-version.mjs
@@ -16,18 +16,18 @@ const version = packageJson.version;
 console.log(`同步版本号: ${version}`);
 
 // 更新 tauri.conf.json
-const tauriConfPath = resolve(root, 'src-tauri/tauri.conf.json');
+const tauriConfPath = resolve(root, 'dns-orchestrator-tauri/tauri.conf.json');
 const tauriConf = JSON.parse(readFileSync(tauriConfPath, 'utf-8'));
 tauriConf.version = version;
 writeFileSync(tauriConfPath, JSON.stringify(tauriConf, null, 2) + '\n');
-console.log('✓ src-tauri/tauri.conf.json');
+console.log('✓ dns-orchestrator-tauri/tauri.conf.json');
 
 // 更新 Tauri Cargo.toml
-const cargoTomlPath = resolve(root, 'src-tauri/Cargo.toml');
+const cargoTomlPath = resolve(root, 'dns-orchestrator-tauri/Cargo.toml');
 let tauriCargoToml = readFileSync(cargoTomlPath, 'utf-8');
 tauriCargoToml = tauriCargoToml.replace(/^version\s*=\s*"[^"]*"/m, `version = "${version}"`);
 writeFileSync(cargoTomlPath, tauriCargoToml);
-console.log('✓ src-tauri/Cargo.toml');
+console.log('✓ dns-orchestrator-tauri/Cargo.toml');
 
 // 更新 Actix-web Cargo.toml
 const actixCargoTomlPath = resolve(root, 'dns-orchestrator-web/Cargo.toml');


### PR DESCRIPTION
将版本同步脚本中的Tauri相关文件路径从`src-tauri`更新为`dns-orchestrator-tauri`，以匹配项目结构调整后的目录名称。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 更新了构建脚本中的内部路径引用和相关日志输出

**备注：** 此版本为基础设施维护更新，不包含用户可见的功能变化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->