### PR TITLE
fix: feat: 前端对于恢复账户的 error 需要提升细粒度

### DIFF
--- a/dns-orchestrator-app/src/lib.rs
+++ b/dns-orchestrator-app/src/lib.rs
@@ -21,7 +21,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use dns_orchestrator_core::error::{CoreError, CoreResult};
 use dns_orchestrator_core::services::{
     AccountService, DnsService, DomainMetadataService, DomainService, ImportExportService,
-    MigrationResult, MigrationService, ProviderMetadataService, ServiceContext,
+    MigrationResult, MigrationService, ProviderMetadataService, RestoreResult, ServiceContext,
 };
 use dns_orchestrator_core::traits::{
     AccountRepository, CredentialStore, DomainMetadataRepository, InMemoryProviderRegistry,
@@ -91,7 +91,7 @@ impl AppState {
     /// stages that may become fallible.
     pub async fn run_startup(&self, hooks: &dyn StartupHooks) -> CoreResult<()> {
         self.run_migration(hooks).await;
-        self.run_account_restore().await;
+        let _ = self.run_account_restore().await;
         Ok(())
     }
 
@@ -165,21 +165,16 @@ impl AppState {
 
     /// Run account restoration and set `restore_completed` to `true` when done.
     ///
-    /// Restoration errors are logged and do not panic.
-    pub async fn run_account_restore(&self) {
-        match self.account_service.restore_accounts().await {
-            Ok(result) => {
-                log::info!(
-                    "Account restoration complete: {} succeeded, {} failed",
-                    result.success_count,
-                    result.error_count
-                );
-            }
-            Err(e) => {
-                log::error!("Failed to restore accounts: {e}");
-            }
-        }
+    /// Returns the detailed restoration result containing per-account errors for frontend display.
+    pub async fn run_account_restore(&self) -> CoreResult<RestoreResult> {
+        let result = self.account_service.restore_accounts().await?;
+        log::info!(
+            "Account restoration complete: {} succeeded, {} failed",
+            result.success_count,
+            result.error_count
+        );
         self.restore_completed.store(true, Ordering::SeqCst);
+        Ok(result)
     }
 }
 


### PR DESCRIPTION
Closes #34

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **功能改进**
  * 账户恢复流程现在会返回详细的恢复结果和统计信息。
  * 恢复失败时会正确报告错误，便于调用方及时发现问题。
  * 启动流程仍会自动执行账户恢复。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->